### PR TITLE
Use goreleaser to build release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,32 +1,30 @@
-before:
-  hooks:
-    - go test -covermode=atomic -race ./go/...
 builds:
 - env:
-    - CGO_ENABLED=0
+  - CGO_ENABLED=0
   goarch:
-    - amd64
+  - amd64
   goos:
-    - linux
-    - darwin
+  - linux
+  - darwin
   ldflags:
-    - -w -s
-    - -X main.AppVersion={{.Commit}}
+  - -s
+  - -w
+  - -X main.AppVersion={{.Tag}}
   main: ./go/cmd/gh-ost/main.go
 checksum:
   name_template: 'checksums.txt'
 changelog:
   sort: asc
 nfpms:
-  - vendor: GitHub
-    homepage: https://github.com/github/gh-ost
-    maintainer: GitHub Engineering <github@github.com>
-    description: A triggerless online schema migration solution for MySQL
-    license: MIT
-    bindir: /usr/bin
-    formats:
-      - deb
-      - rpm
+- vendor: GitHub
+  homepage: https://github.com/github/gh-ost
+  maintainer: GitHub Engineering <github@github.com>
+  description: A triggerless online schema migration solution for MySQL
+  license: MIT
+  bindir: /usr/bin
+  formats:
+  - deb
+  - rpm
 release:
   name_template: "GA release {{.Tag}}"
   github:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+before:
+  hooks:
+    - go test -covermode=atomic -race ./go/...
+builds:
+- env:
+    - CGO_ENABLED=0
+  goarch:
+    - amd64
+  goos:
+    - linux
+    - darwin
+  ldflags:
+    - -w -s
+    - -X main.AppVersion={{.Commit}}
+  main: ./go/cmd/gh-ost/main.go
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+nfpms:
+  - vendor: GitHub
+    homepage: https://github.com/github/gh-ost
+    maintainer: GitHub Engineering <github@github.com>
+    description: A triggerless online schema migration solution for MySQL
+    license: MIT
+    bindir: /usr/bin
+    formats:
+      - deb
+      - rpm
+release:
+  name_template: "GA release {{.Tag}}"
+  github:
+    owner: timvaillancourt
+    name: gh-ost


### PR DESCRIPTION
### Description

This PR adds a GitHub Actions workflow to handle creating release assets when a new tag is made

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
